### PR TITLE
fix tooltip flicker

### DIFF
--- a/src/components/common/BarGraph.css
+++ b/src/components/common/BarGraph.css
@@ -1,0 +1,1 @@
+svg > g > g.google-visualization-tooltip { pointer-events: none }

--- a/src/components/common/BarGraph.js
+++ b/src/components/common/BarGraph.js
@@ -1,6 +1,8 @@
 import { useContext } from 'react'
 import Chart from 'react-google-charts'
 import { ThemeContext } from 'styled-components';
+import './BarGraph.css'
+
 
 const BarGraph = ({ chartEvents, data, enableInteractivity=false, height }) => {
     const theme = useContext(ThemeContext)


### PR DESCRIPTION
Previously if you hovered over the bar and the tooltip appeared under the cursor it would cause it to infinitely appear and disappear.