### PR TITLE
sticky navbar

### DIFF
--- a/src/components/navbar/NavigationBar.css
+++ b/src/components/navbar/NavigationBar.css
@@ -1,0 +1,5 @@
+.navbar-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 9999;
+}

--- a/src/components/navbar/NavigationBar.js
+++ b/src/components/navbar/NavigationBar.js
@@ -11,6 +11,7 @@ import { Button, Form, FormControl, InputGroup, Nav, Navbar, ReactPlaceholder } 
 import '../common/Glow.css'
 import LoginButton from './LoginButton'
 import './NavButton.css'
+import './NavigationBar.css'
 import UploadModal from './UploadModal'
 import UserBadge from './UserBadge'
 
@@ -65,7 +66,7 @@ function NavigationBar({ user, setAuthX, setSearchText, toggleTheme }) {
     )
 
   return (
-    <div>
+    <div className='navbar-sticky'>
       <Navbar bg='dark' variant='dark' expand='lg' className='pl-3'>
         <Large>
           <LinkContainer to='/'>


### PR DESCRIPTION
Added the sticky navbar as stated in #planned-features on Discord.

There is a prop `sticky` for the bootstrap navbar but the nav is currently wrapped in a `div` so it does not work, that's why I added those classes on the parent element.